### PR TITLE
Fix the non-PNG version of the output

### DIFF
--- a/windowpane.rb
+++ b/windowpane.rb
@@ -4,9 +4,11 @@ require 'chunky_png'
 require 'pp'
 
 class String
-	def jsstr
+	def jsstr(quote=nil)
 		out = ''
-		quote = self.include?("'") ? '"' : "'"
+        if not quote
+		    quote = self.include?("'") ? '"' : "'"
+        end
 		self.each_char do |x|
 			case x
 				when "\n" then out += '\n'
@@ -163,7 +165,7 @@ def build(fn, png=false, svg=false)
 	script = ERB.new(File.read(if svg then 'scriptsvg.jst' else 'script.jst' end)).result($binding)
 	script = script.gsub(/@MIN@(.*?)@MIN@/m) do |s|
 		s = s[5...-5]
-		scriptmin(s).jsstr
+		scriptmin(s).jsstr("'")
 	end
 	script = scriptmin script
 	

--- a/windowpane.rb
+++ b/windowpane.rb
@@ -170,7 +170,7 @@ def build(fn, png=false, svg=false)
 	if png or svg
 		doc = script
 	else
-		doc = %Q{<body style=margin:0;overflow:hidden onload="#{script}"><canvas><title>#{title}}
+		doc = %Q{<body id=s style=margin:0;overflow:hidden onload="#{script}"><canvas><title>#{title}}
 	end
 	puts "Size: #{doc.size} bytes"
 	doc


### PR DESCRIPTION
The current HEAD seems to have broken the plain HTML output, at least for me. One problem is that s is undefined, another that double quotes break the onload attribute. These two commits fix that.

Also, thanks for the excellent framework and all the hacking that goes with it! I've been thinking of trying a small WebGL intro of my own, just for fun. Your work on superpacking js demos is amazingly helpful for a newbie such as myself.
